### PR TITLE
Allow merging of data structures

### DIFF
--- a/src/tomlf/all.f90
+++ b/src/tomlf/all.f90
@@ -16,9 +16,13 @@
 module tomlf_all
    use tomlf_build
    use tomlf_constants
+   use tomlf_datetime
    use tomlf_de
+   use tomlf_error
    use tomlf_ser
+   use tomlf_structure
    use tomlf_type
+   use tomlf_utils
    use tomlf_version
    implicit none
    public

--- a/src/tomlf/build.f90
+++ b/src/tomlf/build.f90
@@ -19,11 +19,12 @@
 module tomlf_build
    use tomlf_build_array, only : get_value, set_value
    use tomlf_build_keyval, only : get_value, set_value
+   use tomlf_build_merge, only : merge_table, merge_array
    use tomlf_build_table, only : get_value, set_value
    implicit none
    private
 
-   public :: get_value, set_value
+   public :: get_value, set_value, merge_table, merge_array
 
 
 end module tomlf_build

--- a/src/tomlf/build/CMakeLists.txt
+++ b/src/tomlf/build/CMakeLists.txt
@@ -18,6 +18,7 @@ list(
   APPEND srcs
   "${dir}/array.f90"
   "${dir}/keyval.f90"
+  "${dir}/merge.f90"
   "${dir}/table.f90"
 )
 

--- a/src/tomlf/build/merge.f90
+++ b/src/tomlf/build/merge.f90
@@ -1,0 +1,108 @@
+! This file is part of toml-f.
+!
+! Copyright (C) 2019-2020 Sebastian Ehlert
+!
+! Licensed under either of Apache License, Version 2.0 or MIT license
+! at your option; you may not use this file except in compliance with
+! the License.
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!> Merge TOML data structures
+module tomlf_build_merge
+   use tomlf_constants, only : tfc
+   use tomlf_type, only : toml_table, toml_array, toml_keyval, toml_value, &
+      & toml_key, len
+   implicit none
+   private
+
+   public :: merge_table, merge_array
+
+
+contains
+
+
+!> Merge TOML tables by appending their values
+recursive subroutine merge_table(lhs, rhs)
+
+   !> Instance of table to merge into
+   class(toml_table), intent(inout) :: lhs
+
+   !> Instance of table to be merged
+   class(toml_table), intent(inout) :: rhs
+
+   type(toml_key), allocatable :: list(:)
+   class(toml_value), pointer :: ptr1, ptr2
+   class(toml_value), allocatable :: tmp
+   logical :: has_key
+   integer :: i, n, stat
+
+   call rhs%get_keys(list)
+   n = size(list, 1)
+
+   do i = 1, n
+      call rhs%get(list(i)%key, ptr1)
+      has_key = lhs%has_key(list(i)%key)
+      select type(ptr1)
+      class is(toml_keyval)
+         if (.not.has_key) then
+            tmp = ptr1
+            call lhs%push_back(tmp, stat)
+         end if
+      class is(toml_array)
+         if (has_key) then
+            call lhs%get(list(i)%key, ptr2)
+            select type(ptr2)
+            class is(toml_array)
+               call merge_array(ptr2, ptr1)
+            end select
+         else
+            tmp = ptr1
+            call lhs%push_back(tmp, stat)
+         end if
+      class is(toml_table)
+         if (has_key) then
+            call lhs%get(list(i)%key, ptr2)
+            select type(ptr2)
+            class is(toml_table)
+               call merge_table(ptr2, ptr1)
+            end select
+         else
+            tmp = ptr1
+            call lhs%push_back(tmp, stat)
+         end if
+      end select
+   end do
+
+end subroutine merge_table
+
+
+!> Append values from one TOML array to another
+recursive subroutine merge_array(lhs, rhs)
+
+   !> Instance of array to merge into
+   class(toml_array), intent(inout) :: lhs
+
+   !> Instance of array to be merged
+   class(toml_array), intent(inout) :: rhs
+
+   class(toml_value), pointer :: ptr
+   class(toml_value), allocatable :: tmp
+   integer :: n, i, stat
+
+   n = len(rhs)
+
+   do i = 1, n
+      call rhs%get(i, ptr)
+      tmp = ptr
+      call lhs%push_back(tmp, stat)
+   end do
+
+end subroutine merge_array
+
+
+end module tomlf_build_merge

--- a/src/tomlf/build/meson.build
+++ b/src/tomlf/build/meson.build
@@ -15,5 +15,6 @@
 srcs += files(
   'array.f90',
   'keyval.f90',
+  'merge.f90',
   'table.f90',
 )


### PR DESCRIPTION
Merge policy:
- copy key-value pair in case it is not present in table
- drop key-value pair in case it is present in table
- copy subtable in case it is not present in table
- merge subtable in case it is present in table, using same merge policy
- copy array in case it is not present in table
- append array in case it is present in table