### PR TITLE
Correctly report status for get_child_value on TOML values

### DIFF
--- a/src/tomlf/build/table.f90
+++ b/src/tomlf/build/table.f90
@@ -116,6 +116,8 @@ subroutine get_child_table(table, key, ptr, requested, stat)
    else
       if (is_requested) then
          call add_table(table, key, ptr, stat)
+      else
+         if (present(stat)) stat = toml_stat%fatal
       end if
    end if
 
@@ -163,6 +165,8 @@ subroutine get_child_array(table, key, ptr, requested, stat)
    else
       if (is_requested) then
          call add_array(table, key, ptr, stat)
+      else
+         if (present(stat)) stat = toml_stat%fatal
       end if
    end if
 
@@ -210,6 +214,8 @@ subroutine get_child_keyval(table, key, ptr, requested, stat)
    else
       if (is_requested) then
          call add_keyval(table, key, ptr, stat)
+      else
+         if (present(stat)) stat = toml_stat%fatal
       end if
    end if
 

--- a/src/tomlf/build/table.f90
+++ b/src/tomlf/build/table.f90
@@ -117,7 +117,7 @@ subroutine get_child_table(table, key, ptr, requested, stat)
       if (is_requested) then
          call add_table(table, key, ptr, stat)
       else
-         if (present(stat)) stat = toml_stat%fatal
+         if (present(stat)) stat = toml_stat%success
       end if
    end if
 
@@ -166,7 +166,7 @@ subroutine get_child_array(table, key, ptr, requested, stat)
       if (is_requested) then
          call add_array(table, key, ptr, stat)
       else
-         if (present(stat)) stat = toml_stat%fatal
+         if (present(stat)) stat = toml_stat%success
       end if
    end if
 
@@ -215,7 +215,7 @@ subroutine get_child_keyval(table, key, ptr, requested, stat)
       if (is_requested) then
          call add_keyval(table, key, ptr, stat)
       else
-         if (present(stat)) stat = toml_stat%fatal
+         if (present(stat)) stat = toml_stat%success
       end if
    end if
 

--- a/test/tftest/build.f90
+++ b/test/tftest/build.f90
@@ -40,7 +40,7 @@ subroutine collect_build(testsuite)
       & new_unittest("array-int-i4", array_int_i4), &
       & new_unittest("array-int-i8", array_int_i8), &
       & new_unittest("array-bool", array_bool), &
-      & new_unittest("array-merge", table_merge), &
+      & new_unittest("array-merge", array_merge), &
       & new_unittest("table-real-sp", table_real_sp), &
       & new_unittest("table-real-dp", table_real_dp), &
       & new_unittest("table-int-i1", table_int_i1), &
@@ -49,7 +49,7 @@ subroutine collect_build(testsuite)
       & new_unittest("table-int-i8", table_int_i8), &
       & new_unittest("table-bool", table_bool), &
       & new_unittest("table-string", table_string), &
-      & new_unittest("table-merge", array_merge)]
+      & new_unittest("table-merge", table_merge)]
 
 end subroutine collect_build
 


### PR DESCRIPTION
Status of operation had to be inferred from association status of pointer for `requested=.false.` case.