### PR TITLE
Use target based CMake approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ project(
   "toml-f"
   LANGUAGES "Fortran"
   VERSION "0.2.0"
+  DESCRIPTION "A TOML parser implementation for data serialization and deserialization in Fortran"
 )
 
 # Follow GNU conventions for installing directories
@@ -43,30 +44,40 @@ set_target_properties(
   OUTPUT_NAME "${PROJECT_NAME}"
   VERSION "${PROJECT_VERSION}"
   SOVERSION "${PROJECT_VERSION_MAJOR}"
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
 )
 target_include_directories(
   "${PROJECT_NAME}-lib"
   INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 if(NOT is-subproject OR BUILD_SHARED_LIBS)
   # Export targets for other projects
+  add_library("${PROJECT_NAME}" INTERFACE)
+  target_link_libraries("${PROJECT_NAME}" INTERFACE "${PROJECT_NAME}-lib")
   install(
     TARGETS
+    "${PROJECT_NAME}"
     "${PROJECT_NAME}-lib"
     EXPORT
-    "${PROJECT_NAME}-config"
+    "${PROJECT_NAME}-targets"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   )
-
   install(
-    EXPORT "${PROJECT_NAME}-config"
+    EXPORT
+    "${PROJECT_NAME}-targets"
+    NAMESPACE
+    "${PROJECT_NAME}::"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   )
-
+  install(
+    DIRECTORY
+    "${CMAKE_CURRENT_BINARY_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
   # Package license files
   install(
     FILES

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -26,3 +26,34 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Setting build type to '${CMAKE_BUILD_TYPE}' as none was specified."
   )
 endif()
+
+if(NOT is-subproject OR BUILD_SHARED_LIBS)
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/template.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  )
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMinorVersion
+  )
+  install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  )
+
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/template.pc"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    @ONLY
+  )
+  install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
+endif()

--- a/config/template.cmake
+++ b/config/template.cmake
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET "@PROJECT_NAME@::@PROJECT_NAME@")
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+endif()

--- a/config/template.pc
+++ b/config/template.pc
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}

--- a/test/json_de.f90
+++ b/test/json_de.f90
@@ -15,7 +15,6 @@
 !> Implementation of a deserializer for a specific JSON format
 module tftest_json_de
    use iso_fortran_env, only: error_unit
-   use tomlf_ser, only : toml_serializer
    use tomlf_build, only : get_value, set_value
    use tomlf_constants
    use tomlf_error, only : toml_stat, toml_error, toml_context, &
@@ -247,7 +246,6 @@ subroutine parse_root(de)
    !> Instance of the TOML deserializer
    class(json_deserializer), intent(inout), target :: de
    type(json_prune) :: pruner
-   type(toml_serializer) :: ser
 
    allocate(de%root)
    call new_table(de%root)
@@ -333,7 +331,7 @@ subroutine parse_keyval(de, table)
    type(toml_keyval), pointer :: vptr
    type(toml_array), pointer :: aptr
    type(toml_table), pointer :: tptr
-   character(kind=tfc, len=:), allocatable :: new_key, this_key
+   character(kind=tfc, len=:), allocatable :: new_key
 
    !print*, 'enter parse_keyval'
 


### PR DESCRIPTION
- create `toml-f` interface target for external dependencies
- export everything with `toml-f::` namespace
- “correct” setup for CMake package files (`*-config.cmake`, `*-config-version.cmake`, `*-targets.cmake`)