### PR TITLE
Disable automatic discovery of tests with fpm

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -4,3 +4,6 @@ license = "Apache-2.0 OR MIT"
 
 [library]
 source-dir = "src"
+
+[build]
+auto-tests = false


### PR DESCRIPTION
Automatic discovery of tests will fail to discover the correct tests for this project, also some tests require input which cannot be provided by fpm yet.