### PR TITLE
Add SPDX license identifiers to all files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2019-2020 Sebastian Ehlert
+Copyright 2019-2021 Sebastian Ehlert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/config/meson.build
+++ b/config/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,6 +1,12 @@
 name = "toml-f"
 version = "0.2.1"
 license = "Apache-2.0 OR MIT"
+maintainer = ["@awvwgk"]
+author = ["Sebastian Ehlert"]
+copyright = "2019-2021 Sebastian Ehlert"
+homepage = "https://toml-f.github.io/toml-f"
+keywords = ["toml", "io", "serde"]
+description = "TOML parser implementation for data serialization and deserialization"
 
 [library]
 source-dir = "src"

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with
@@ -16,7 +15,7 @@ project(
   'toml-f',
   'fortran',
   version: '0.2.1',
-  license: 'MIT OR Apache-2.0',
+  license: 'Apache-2.0 OR MIT',
   meson_version: '>=0.53',
   default_options: [
     'buildtype=debugoptimized',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf.f90
+++ b/src/tomlf.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/CMakeLists.txt
+++ b/src/tomlf/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/all.f90
+++ b/src/tomlf/all.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/build.f90
+++ b/src/tomlf/build.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/CMakeLists.txt
+++ b/src/tomlf/build/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/array.f90
+++ b/src/tomlf/build/array.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/keyval.f90
+++ b/src/tomlf/build/keyval.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/merge.f90
+++ b/src/tomlf/build/merge.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/meson.build
+++ b/src/tomlf/build/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/build/table.f90
+++ b/src/tomlf/build/table.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/constants.f90
+++ b/src/tomlf/constants.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/datetime.f90
+++ b/src/tomlf/datetime.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/de.f90
+++ b/src/tomlf/de.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/de/CMakeLists.txt
+++ b/src/tomlf/de/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/de/character.f90
+++ b/src/tomlf/de/character.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/de/meson.build
+++ b/src/tomlf/de/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/de/tokenizer.f90
+++ b/src/tomlf/de/tokenizer.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/error.f90
+++ b/src/tomlf/error.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/meson.build
+++ b/src/tomlf/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/ser.f90
+++ b/src/tomlf/ser.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/structure.f90
+++ b/src/tomlf/structure.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/structure/CMakeLists.txt
+++ b/src/tomlf/structure/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/structure/base.f90
+++ b/src/tomlf/structure/base.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/structure/meson.build
+++ b/src/tomlf/structure/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/structure/vector.f90
+++ b/src/tomlf/structure/vector.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/type.f90
+++ b/src/tomlf/type.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/CMakeLists.txt
+++ b/src/tomlf/type/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/array.f90
+++ b/src/tomlf/type/array.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/keyval.f90
+++ b/src/tomlf/type/keyval.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/meson.build
+++ b/src/tomlf/type/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/table.f90
+++ b/src/tomlf/type/table.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/type/value.f90
+++ b/src/tomlf/type/value.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/utils.f90
+++ b/src/tomlf/utils.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/utils/CMakeLists.txt
+++ b/src/tomlf/utils/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/utils/convert.f90
+++ b/src/tomlf/utils/convert.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/utils/meson.build
+++ b/src/tomlf/utils/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/src/tomlf/utils/verify.f90
+++ b/src/tomlf/utils/verify.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/src/tomlf/version.f90
+++ b/src/tomlf/version.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/example-1/app/main.f90
+++ b/test/example-1/app/main.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/app/meson.build
+++ b/test/example-1/app/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/example-1/meson.build
+++ b/test/example-1/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/example-1/src/meson.build
+++ b/test/example-1/src/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg.f90
+++ b/test/example-1/src/pkg.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/compatibility.f90
+++ b/test/example-1/src/pkg/compatibility.f90
@@ -1,4 +1,5 @@
 ! This file is part of toml-f.
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Copyright (C) 2019-2020 Sebastian Ehlert
 !

--- a/test/example-1/src/pkg/dependency.f90
+++ b/test/example-1/src/pkg/dependency.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/error.f90
+++ b/test/example-1/src/pkg/error.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/meson.build
+++ b/test/example-1/src/pkg/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/package.f90
+++ b/test/example-1/src/pkg/package.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/source.f90
+++ b/test/example-1/src/pkg/source.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/example-1/src/pkg/toml.f90
+++ b/test/example-1/src/pkg/toml.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/fpm.f90
+++ b/test/fpm.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/json2toml.f90
+++ b/test/json2toml.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/json_de.f90
+++ b/test/json_de.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/json_ser.f90
+++ b/test/json_ser.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/tftest.f90
+++ b/test/tftest.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/tftest/CMakeLists.txt
+++ b/test/tftest/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/tftest/build.f90
+++ b/test/tftest/build.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/tftest/meson.build
+++ b/test/tftest/meson.build
@@ -1,6 +1,5 @@
 # This file is part of toml-f.
-#
-# Copyright (C) 2019-2020 Sebastian Ehlert
+# SPDX-Identifier: Apache-2.0 OR MIT
 #
 # Licensed under either of Apache License, Version 2.0 or MIT license
 # at your option; you may not use this file except in compliance with

--- a/test/tftest/testsuite.f90
+++ b/test/tftest/testsuite.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/toml2json.f90
+++ b/test/toml2json.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with

--- a/test/version.f90
+++ b/test/version.f90
@@ -1,6 +1,5 @@
 ! This file is part of toml-f.
-!
-! Copyright (C) 2019-2020 Sebastian Ehlert
+! SPDX-Identifier: Apache-2.0 OR MIT
 !
 ! Licensed under either of Apache License, Version 2.0 or MIT license
 ! at your option; you may not use this file except in compliance with


### PR DESCRIPTION
Also removes the copyright notice from all source files, because they are tedious to update.