### PR TITLE
Allow using toml_keys as input for tables in the build interface

### DIFF
--- a/src/tomlf/build/table.f90
+++ b/src/tomlf/build/table.f90
@@ -35,7 +35,8 @@ module tomlf_build_table
       & tf_sp, tf_dp
    use tomlf_error, only : toml_stat
    use tomlf_type, only : toml_value, toml_table, toml_array, toml_keyval, &
-      & new_table, new_array, new_keyval, add_table, add_array, add_keyval, len
+      & new_table, new_array, new_keyval, add_table, add_array, add_keyval, &
+      & toml_key, len
    implicit none
    private
 
@@ -52,6 +53,14 @@ module tomlf_build_table
       module procedure :: set_child_value_integer_i8
       module procedure :: set_child_value_bool
       module procedure :: set_child_value_string
+      module procedure :: set_key_value_float_sp
+      module procedure :: set_key_value_float_dp
+      module procedure :: set_key_value_integer_i1
+      module procedure :: set_key_value_integer_i2
+      module procedure :: set_key_value_integer_i4
+      module procedure :: set_key_value_integer_i8
+      module procedure :: set_key_value_bool
+      module procedure :: set_key_value_string
    end interface set_value
 
 
@@ -68,10 +77,431 @@ module tomlf_build_table
       module procedure :: get_child_value_integer_i8
       module procedure :: get_child_value_bool
       module procedure :: get_child_value_string
+      module procedure :: get_key_table
+      module procedure :: get_key_array
+      module procedure :: get_key_keyval
+      module procedure :: get_key_value_float_sp
+      module procedure :: get_key_value_float_dp
+      module procedure :: get_key_value_integer_i1
+      module procedure :: get_key_value_integer_i2
+      module procedure :: get_key_value_integer_i4
+      module procedure :: get_key_value_integer_i8
+      module procedure :: get_key_value_bool
+      module procedure :: get_key_value_string
    end interface get_value
 
 
 contains
+
+
+subroutine get_key_table(table, key, ptr, requested, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Pointer to child table
+   type(toml_table), pointer, intent(out) :: ptr
+
+   !> Child value must be present
+   logical, intent(in), optional :: requested
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, ptr, requested, stat)
+
+end subroutine get_key_table
+
+
+subroutine get_key_array(table, key, ptr, requested, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Pointer to child array
+   type(toml_array), pointer, intent(out) :: ptr
+
+   !> Child value must be present
+   logical, intent(in), optional :: requested
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, ptr, requested, stat)
+
+end subroutine get_key_array
+
+
+subroutine get_key_keyval(table, key, ptr, requested, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Pointer to child value
+   type(toml_keyval), pointer, intent(out) :: ptr
+
+   !> Child value must be present
+   logical, intent(in), optional :: requested
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, ptr, requested, stat)
+
+end subroutine get_key_keyval
+
+
+!> Retrieve TOML value as single precision float (might lose accuracy)
+subroutine get_key_value_float_sp(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Real value
+   real(tf_sp), intent(out) :: val
+
+   !> Default real value
+   real(tf_sp), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_float_sp
+
+
+!> Retrieve TOML value as double precision float
+subroutine get_key_value_float_dp(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Real value
+   real(tf_dp), intent(out) :: val
+
+   !> Default real value
+   real(tf_dp), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_float_dp
+
+
+!> Retrieve TOML value as one byte integer (might loose precision)
+subroutine get_key_value_integer_i1(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i1), intent(out) :: val
+
+   !> Default integer value
+   integer(tf_i1), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_integer_i1
+
+
+!> Retrieve TOML value as two byte integer (might loose precision)
+subroutine get_key_value_integer_i2(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i2), intent(out) :: val
+
+   !> Default integer value
+   integer(tf_i2), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_integer_i2
+
+
+!> Retrieve TOML value as four byte integer (might loose precision)
+subroutine get_key_value_integer_i4(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i4), intent(out) :: val
+
+   !> Default integer value
+   integer(tf_i4), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_integer_i4
+
+
+!> Retrieve TOML value as eight byte integer
+subroutine get_key_value_integer_i8(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i8), intent(out) :: val
+
+   !> Default integer value
+   integer(tf_i8), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_integer_i8
+
+
+!> Retrieve TOML value as logical
+subroutine get_key_value_bool(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Boolean value
+   logical, intent(out) :: val
+
+   !> Default boolean value
+   logical, intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_bool
+
+
+!> Retrieve TOML value as deferred-length character
+subroutine get_key_value_string(table, key, val, default, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> String value
+   character(kind=tfc, len=:), allocatable, intent(out) :: val
+
+   !> Default string value
+   character(kind=tfc, len=*), intent(in), optional :: default
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call get_value(table, key%key, val, default, stat)
+
+end subroutine get_key_value_string
+
+
+!> Set TOML value to single precision float
+subroutine set_key_value_float_sp(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Real value
+   real(tf_sp), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_float_sp
+
+
+!> Set TOML value to double precision float
+subroutine set_key_value_float_dp(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Real value
+   real(tf_dp), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_float_dp
+
+
+!> Set TOML value to one byte integer
+subroutine set_key_value_integer_i1(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i1), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_integer_i1
+
+
+!> Set TOML value to two byte integer
+subroutine set_key_value_integer_i2(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i2), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_integer_i2
+
+
+!> Set TOML value to four byte integer
+subroutine set_key_value_integer_i4(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i4), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_integer_i4
+
+
+!> Set TOML value to eight byte integer
+subroutine set_key_value_integer_i8(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Integer value
+   integer(tf_i8), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_integer_i8
+
+
+!> Set TOML value to logical
+subroutine set_key_value_bool(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> Boolean value
+   logical, intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_bool
+
+
+!> Set TOML value to deferred-length character
+subroutine set_key_value_string(table, key, val, stat)
+
+   !> Instance of the TOML table
+   class(toml_table), intent(inout) :: table
+
+   !> Key in this TOML table
+   type(toml_key), intent(in) :: key
+
+   !> String value
+   character(kind=tfc, len=*), intent(in) :: val
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   call set_value(table, key%key, val, stat)
+
+end subroutine set_key_value_string
 
 
 subroutine get_child_table(table, key, ptr, requested, stat)

--- a/test/tftest/build.f90
+++ b/test/tftest/build.f90
@@ -57,7 +57,7 @@ end subroutine collect_build
 !> Check double precision floating point numbers (default)
 subroutine table_real_dp(error)
    use tomlf_constants, only : tf_dp
-   use tomlf_type, only : new_table, toml_table
+   use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -75,8 +75,8 @@ subroutine table_real_dp(error)
    if (allocated(error)) return
 
    call table%delete("real")
-   call set_value(table, "real", in1, stat=stat)
-   call get_value(table, "real", val, stat=stat)
+   call set_value(table, toml_key("real"), in1, stat=stat)
+   call get_value(table, toml_key("real"), val, stat=stat)
 
    call check(error, val, in1)
    if (allocated(error)) return
@@ -97,7 +97,7 @@ end subroutine table_real_dp
 !  larger deviations here than just epsilon.
 subroutine table_real_sp(error)
    use tomlf_constants, only : tf_sp
-   use tomlf_type, only : new_table, toml_table
+   use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -109,8 +109,8 @@ subroutine table_real_sp(error)
    integer :: stat
 
    call new_table(table)
-   call set_value(table, "real", in2, stat=stat)
-   call get_value(table, "real", val, stat=stat)
+   call set_value(table, toml_key("real"), in2, stat=stat)
+   call get_value(table, toml_key("real"), val, stat=stat)
 
    call check(error, val, in2, thr=thr, rel=.true.)
    if (allocated(error)) return
@@ -132,10 +132,10 @@ subroutine table_real_sp(error)
 end subroutine table_real_sp
 
 
-!> Check double precision floating point numbers (default)
+!> Check smallest integers (char)
 subroutine table_int_i1(error)
    use tomlf_constants, only : tf_i1
-   use tomlf_type, only : new_table, toml_table
+   use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -146,7 +146,7 @@ subroutine table_int_i1(error)
    integer :: stat
 
    call new_table(table)
-   call set_value(table, "int", in2, stat=stat)
+   call set_value(table, toml_key("int"), in2, stat=stat)
    call get_value(table, "int", val, stat=stat)
 
    call check(error, val, in2)
@@ -154,7 +154,7 @@ subroutine table_int_i1(error)
 
    call table%delete("int")
    call set_value(table, "int", in1, stat=stat)
-   call get_value(table, "int", val, stat=stat)
+   call get_value(table, toml_key("int"), val, stat=stat)
 
    call check(error, val, in1)
    if (allocated(error)) return
@@ -169,7 +169,7 @@ subroutine table_int_i1(error)
 end subroutine table_int_i1
 
 
-!> Check double precision floating point numbers (default)
+!> Check short integers
 subroutine table_int_i2(error)
    use tomlf_constants, only : tf_i2
    use tomlf_type, only : new_table, toml_table
@@ -183,8 +183,8 @@ subroutine table_int_i2(error)
    integer :: stat
 
    call new_table(table)
-   call set_value(table, "int", in2, stat=stat)
-   call get_value(table, "int", val, stat=stat)
+   call set_value(table, toml_key("int"), in2, stat=stat)
+   call get_value(table, toml_key("int"), val, stat=stat)
 
    call check(error, val, in2)
    if (allocated(error)) return
@@ -206,10 +206,10 @@ subroutine table_int_i2(error)
 end subroutine table_int_i2
 
 
-!> Check double precision floating point numbers (default)
+!> Check default integers
 subroutine table_int_i4(error)
    use tomlf_constants, only : tf_i4
-   use tomlf_type, only : new_table, toml_table
+   use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -227,8 +227,8 @@ subroutine table_int_i4(error)
    if (allocated(error)) return
 
    call table%delete("int")
-   call set_value(table, "int", in1, stat=stat)
-   call get_value(table, "int", val, stat=stat)
+   call set_value(table, toml_key("int"), in1, stat=stat)
+   call get_value(table, toml_key("int"), val, stat=stat)
 
    call check(error, val, in1)
    if (allocated(error)) return
@@ -243,10 +243,10 @@ subroutine table_int_i4(error)
 end subroutine table_int_i4
 
 
-!> Check double precision floating point numbers (default)
+!> Check long integers (default)
 subroutine table_int_i8(error)
    use tomlf_constants, only : tf_i8
-   use tomlf_type, only : new_table, toml_table
+   use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -264,7 +264,7 @@ subroutine table_int_i8(error)
    if (allocated(error)) return
 
    call table%delete("int")
-   call set_value(table, "int", in1, stat=stat)
+   call set_value(table, toml_key("int"), in1, stat=stat)
    call get_value(table, "int", val, stat=stat)
 
    call check(error, val, in1)
@@ -272,7 +272,7 @@ subroutine table_int_i8(error)
 
    call table%destroy
    call new_table(table)
-   call get_value(table, "int", val, in3, stat=stat)
+   call get_value(table, toml_key("int"), val, in3, stat=stat)
 
    call check(error, val, in3)
    if (allocated(error)) return
@@ -280,9 +280,9 @@ subroutine table_int_i8(error)
 end subroutine table_int_i8
 
 
-!> Check double precision floating point numbers (default)
+!> Check logicals
 subroutine table_bool(error)
-   use tomlf_type, only : toml_table
+   use tomlf_type, only : toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -293,8 +293,8 @@ subroutine table_bool(error)
    integer :: stat
 
    table = toml_table()
-   call set_value(table, "logic", true, stat=stat)
-   call get_value(table, "logic", val, stat=stat)
+   call set_value(table, toml_key("logic"), true, stat=stat)
+   call get_value(table, toml_key("logic"), val, stat=stat)
 
    call check(error, val, true)
    if (allocated(error)) return
@@ -316,9 +316,9 @@ subroutine table_bool(error)
 end subroutine table_bool
 
 
-!> Check double precision floating point numbers (default)
+!> Check strings
 subroutine table_string(error)
-   use tomlf_type, only : toml_table
+   use tomlf_type, only : toml_table, toml_key
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -328,7 +328,7 @@ subroutine table_string(error)
    integer :: stat
 
    table = toml_table()
-   call set_value(table, "string", "value", stat=stat)
+   call set_value(table, toml_key("string"), "value", stat=stat)
    call get_value(table, "string", val, stat=stat)
 
    call check(error, val, "value")
@@ -343,7 +343,7 @@ subroutine table_string(error)
 
    call table%destroy
    call new_table(table)
-   call get_value(table, "string", val, "'value'", stat=stat)
+   call get_value(table, toml_key("string"), val, "'value'", stat=stat)
 
    call check(error, val, "value")
    if (allocated(error)) return
@@ -409,7 +409,7 @@ subroutine table_array(error)
 end subroutine table_array
 
 
-!> Check double precision floating point numbers (default)
+!> Check single precision floating point numbers
 subroutine array_real_sp(error)
    use tomlf_constants, only : tf_sp
    use tomlf_type, only : new_array, toml_array, len
@@ -465,7 +465,7 @@ subroutine array_real_dp(error)
 end subroutine array_real_dp
 
 
-!> Check double precision floating point numbers (default)
+!> Check smallest integers (char)
 subroutine array_int_i1(error)
    use tomlf_constants, only : tf_i1
    use tomlf_type, only : new_array, toml_array, len
@@ -494,7 +494,7 @@ subroutine array_int_i1(error)
 end subroutine array_int_i1
 
 
-!> Check double precision floating point numbers (default)
+!> Check short integers
 subroutine array_int_i2(error)
    use tomlf_constants, only : tf_i2
    use tomlf_type, only : new_array, toml_array, len
@@ -523,7 +523,7 @@ subroutine array_int_i2(error)
 end subroutine array_int_i2
 
 
-!> Check double precision floating point numbers (default)
+!> Check default integers
 subroutine array_int_i4(error)
    use tomlf_constants, only : tf_i4
    use tomlf_type, only : new_array, toml_array, len
@@ -552,7 +552,7 @@ subroutine array_int_i4(error)
 end subroutine array_int_i4
 
 
-!> Check double precision floating point numbers (default)
+!> Check long integers (default)
 subroutine array_int_i8(error)
    use tomlf_constants, only : tf_i8
    use tomlf_type, only : new_array, toml_array, len
@@ -581,7 +581,7 @@ subroutine array_int_i8(error)
 end subroutine array_int_i8
 
 
-!> Check double precision floating point numbers (default)
+!> Check logicals
 subroutine array_bool(error)
    use tomlf_type, only : toml_array, len
 

--- a/test/tftest/build.f90
+++ b/test/tftest/build.f90
@@ -352,7 +352,7 @@ end subroutine table_string
 
 subroutine table_array(error)
    use tomlf_type, only : toml_value, new_table, toml_table, add_table, new_array, &
-      & toml_array, add_array, len
+      & toml_array, toml_key, add_array, len
 
    !> Error handling
    type(toml_error), allocatable, intent(out) :: error
@@ -364,7 +364,8 @@ subroutine table_array(error)
    integer :: i, stat
 
    call new_table(table)
-   call get_value(table, "array-of-tables", children, requested=.false., stat=stat)
+   call get_value(table, toml_key("array-of-tables"), children, &
+      & requested=.false., stat=stat)
    call check(error, stat, "Not finding a not required value shouldn't be an error")
    if (allocated(error)) return
 


### PR DESCRIPTION
Second argument which is usually a string can now also be a toml_key