### PR TITLE
TOML 1.0.0 is out

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A TOML parser implementation for data serialization and deserialization in Fortran.
 
 * the [TOML standard](https://toml.io)
-* currently supported [TOML v1.0.0-rc3 specification](https://toml.io/en/v1.0.0-rc.3)
+* currently supported [TOML v1.0.0 specification](https://toml.io/en/v1.0.0)
 
 <div align="center">
 <img src="./assets/toml-f.png" alt="TOML-Fortran" width="220">

--- a/docs.md
+++ b/docs.md
@@ -32,7 +32,7 @@ md_extensions: markdown.extensions.toc
 A TOML parser implementation for data serialization and deserialization in Fortran.
 
 * the [TOML standard](https://toml.io)
-* currently supported [TOML v1.0.0-rc3 specification](https://toml.io/en/v1.0.0-rc.3)
+* currently supported [TOML v1.0.0 specification](https://toml.io/en/v1.0.0)
 * the [TOML-Fortran project](https://github.com/toml-f/toml-f)
 
 


### PR DESCRIPTION
No big spec changes in TOML but clarifications, therefore toml-f is already 1.0.0 compliant.