### PR TITLE
fixed revision for awvwgk/test-drive

### DIFF
--- a/config/cmake/Findtest-drive.cmake
+++ b/config/cmake/Findtest-drive.cmake
@@ -14,7 +14,7 @@
 set(_lib "test-drive")
 set(_pkg "TEST_DRIVE")
 set(_url "https://github.com/awvwgk/test-drive")
-set(_rev "v0.4.0")
+set(_rev "v0.3.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")


### PR DESCRIPTION
https://github.com/awvwgk/test-drive has the only  tag 0.3.0, while the current version of `config/Findtest-drive.cmake` points to the non-existing tag 0.4.0