### PR TITLE
Add whole array setters and getters to build interface

### DIFF
--- a/doc/how-to/array.rst
+++ b/doc/how-to/array.rst
@@ -42,6 +42,18 @@ This is achieved through the generic ``get_value`` interface, which automaticall
    By passing an integer value to the optional *stat* argument, the procedure will return a non-zero value to indicate an error.
 
 
+Accessing whole arrays
+----------------------
+
+If the entries of an array are all of the same type or can be safely casted to a common type it is possible to retrieve a whole array using a single call to ``get_value``.
+
+.. literalinclude:: array/whole/app/main.f90
+  :caption: app/parse_array.f90
+  :language: Fortran
+
+The build interface will allocate the array to the correct size and then iterate over all elements and assign them to the array.
+
+
 Accessing nested arrays
 -----------------------
 

--- a/doc/how-to/array/whole/app/main.f90
+++ b/doc/how-to/array/whole/app/main.f90
@@ -1,0 +1,27 @@
+program array
+  use tomlf, only : toml_table, toml_array, get_value, &
+                  & toml_parse, toml_error, len
+
+  implicit none
+  integer, dimension(:), allocatable  :: arr_data
+  integer                             :: data_len, io, i
+  type(toml_table), allocatable       :: table
+  type(toml_array), pointer           :: arr
+  type(toml_error), allocatable       :: parse_error
+
+  open(newunit=io, file="array.toml")
+  call toml_parse(table, io, parse_error)
+  close(unit=io)
+  if (allocated(parse_error)) then
+    print*, "Error parsing table:"//parse_error%message
+  end if
+
+  call get_value(table, "data", arr)
+  if (associated(arr)) then
+    call get_value(arr, arr_data)
+  end if
+
+  print*, "data = ", arr_data
+
+end program
+

--- a/doc/how-to/array/whole/fpm.toml
+++ b/doc/how-to/array/whole/fpm.toml
@@ -1,0 +1,4 @@
+name = "demo"
+
+[dependencies]
+toml-f.path = "../../../.."

--- a/src/tomlf/build/array.f90
+++ b/src/tomlf/build/array.f90
@@ -60,6 +60,14 @@ module tomlf_build_array
       module procedure :: set_elem_value_int_i8
       module procedure :: set_elem_value_bool
       module procedure :: set_elem_value_datetime
+      module procedure :: set_array_value_float_sp
+      module procedure :: set_array_value_float_dp
+      module procedure :: set_array_value_int_i1
+      module procedure :: set_array_value_int_i2
+      module procedure :: set_array_value_int_i4
+      module procedure :: set_array_value_int_i8
+      module procedure :: set_array_value_bool
+      module procedure :: set_array_value_datetime
    end interface set_value
 
 
@@ -77,6 +85,14 @@ module tomlf_build_array
       module procedure :: get_elem_value_int_i8
       module procedure :: get_elem_value_bool
       module procedure :: get_elem_value_datetime
+      module procedure :: get_array_value_float_sp
+      module procedure :: get_array_value_float_dp
+      module procedure :: get_array_value_int_i1
+      module procedure :: get_array_value_int_i2
+      module procedure :: get_array_value_int_i4
+      module procedure :: get_array_value_int_i8
+      module procedure :: get_array_value_bool
+      module procedure :: get_array_value_datetime
    end interface get_value
 
 
@@ -816,6 +832,478 @@ subroutine set_elem_value_datetime(array, pos, val, stat, origin)
    end if
 
 end subroutine set_elem_value_datetime
+
+
+!> Retrieve TOML value as single precision floating point number
+subroutine get_array_value_float_sp(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Floating point value
+   real(tf_sp), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_float_sp
+
+
+!> Retrieve TOML value as double precision floating point number
+subroutine get_array_value_float_dp(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Floating point value
+   real(tf_dp), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_float_dp
+
+
+!> Retrieve TOML value as integer value
+subroutine get_array_value_int_i1(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i1), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_int_i1
+
+
+!> Retrieve TOML value as integer value
+subroutine get_array_value_int_i2(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i2), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_int_i2
+
+
+!> Retrieve TOML value as integer value
+subroutine get_array_value_int_i4(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i4), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_int_i4
+
+
+!> Retrieve TOML value as integer value
+subroutine get_array_value_int_i8(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i8), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_int_i8
+
+
+!> Retrieve TOML value as boolean
+subroutine get_array_value_bool(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   logical, allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_bool
+
+
+!> Retrieve TOML value as datetime
+subroutine get_array_value_datetime(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   type(toml_datetime), allocatable, intent(out) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it, info
+
+   allocate(val(len(array)))
+   do it = 1, size(val)
+      call get_value(array, it, val(it), info, origin)
+      if (info /= 0) exit
+   end do
+   if (info /= 0) deallocate(val)
+   if (present(stat)) stat = info
+   if (present(origin) .and. info == 0) origin = array%origin
+
+end subroutine get_array_value_datetime
+
+
+!> Retrieve TOML value as single precision floating point number
+subroutine set_array_value_float_sp(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Floating point value
+   real(tf_sp), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_float_sp
+
+
+!> Retrieve TOML value as double precision floating point number
+subroutine set_array_value_float_dp(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Floating point value
+   real(tf_dp), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_float_dp
+
+
+!> Retrieve TOML value as integer value
+subroutine set_array_value_int_i1(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i1), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_int_i1
+
+
+!> Retrieve TOML value as integer value
+subroutine set_array_value_int_i2(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i2), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_int_i2
+
+
+!> Retrieve TOML value as integer value
+subroutine set_array_value_int_i4(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i4), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_int_i4
+
+
+!> Retrieve TOML value as integer value
+subroutine set_array_value_int_i8(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Integer value
+   integer(tf_i8), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_int_i8
+
+
+!> Retrieve TOML value as boolean value
+subroutine set_array_value_bool(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Boolean value
+   logical, intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_bool
+
+
+!> Retrieve TOML value as datetime value
+subroutine set_array_value_datetime(array, val, stat, origin)
+
+   !> Instance of the TOML array
+   class(toml_array), intent(inout) :: array
+
+   !> Datetime value
+   type(toml_datetime), intent(in) :: val(:)
+
+   !> Status of operation
+   integer, intent(out), optional :: stat
+
+   !> Origin in the data structure
+   integer, intent(out), optional :: origin
+
+   integer :: it
+   class(toml_value), allocatable :: ptr
+
+   do while(len(array) > size(val))
+      call array%pop(ptr)
+   end do
+
+   do it = 1, size(val)
+      call set_value(array, it, val(it), stat, origin)
+   end do
+   if (present(origin)) origin = array%origin
+
+end subroutine set_array_value_datetime
 
 
 end module tomlf_build_array

--- a/src/tomlf/build/keyval.f90
+++ b/src/tomlf/build/keyval.f90
@@ -81,27 +81,29 @@ subroutine get_value_float_sp(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    real(tfr), pointer :: dummy
    integer(tfi), pointer :: idummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = real(dummy, tf_sp)
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
       call self%get(idummy)
       if (associated(idummy)) then
          val = real(idummy, tf_sp)
          if (nint(val, tfi) == idummy) then
-            if (present(stat)) stat = toml_stat%success
+            info = toml_stat%success
          else
-            if (present(stat)) stat = toml_stat%conversion_error
+            info = toml_stat%conversion_error
          end if
       else
-         if (present(stat)) stat = toml_stat%type_mismatch
+         info = toml_stat%type_mismatch
       end if
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_float_sp
 
@@ -121,27 +123,29 @@ subroutine get_value_float_dp(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    real(tfr), pointer :: dummy
    integer(tfi), pointer :: idummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = real(dummy, tf_dp)
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
       call self%get(idummy)
       if (associated(idummy)) then
          val = real(idummy, tf_dp)
          if (nint(val, tfi) == idummy) then
-            if (present(stat)) stat = toml_stat%success
+            info = toml_stat%success
          else
-            if (present(stat)) stat = toml_stat%conversion_error
+            info = toml_stat%conversion_error
          end if
       else
-         if (present(stat)) stat = toml_stat%type_mismatch
+         info = toml_stat%type_mismatch
       end if
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_float_dp
 
@@ -161,20 +165,22 @@ subroutine get_value_integer_i1(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    integer(tfi), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i1)
       if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
-         if (present(stat)) stat = toml_stat%success
+         info = toml_stat%success
       else
-         if (present(stat)) stat = toml_stat%conversion_error
+         info = toml_stat%conversion_error
       end if
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_integer_i1
 
@@ -194,20 +200,22 @@ subroutine get_value_integer_i2(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    integer(tfi), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i2)
       if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
-         if (present(stat)) stat = toml_stat%success
+         info = toml_stat%success
       else
-         if (present(stat)) stat = toml_stat%conversion_error
+         info = toml_stat%conversion_error
       end if
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_integer_i2
 
@@ -227,20 +235,22 @@ subroutine get_value_integer_i4(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    integer(tfi), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i4)
       if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
-         if (present(stat)) stat = toml_stat%success
+         info = toml_stat%success
       else
-         if (present(stat)) stat = toml_stat%conversion_error
+         info = toml_stat%conversion_error
       end if
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_integer_i4
 
@@ -260,16 +270,18 @@ subroutine get_value_integer_i8(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    integer(tfi), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i8)
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_integer_i8
 
@@ -289,16 +301,18 @@ subroutine get_value_bool(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    logical, pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = dummy
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_bool
 
@@ -318,16 +332,18 @@ subroutine get_value_datetime(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    type(toml_datetime), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = dummy
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_datetime
 
@@ -347,16 +363,18 @@ subroutine get_value_string(self, val, stat, origin)
    !> Origin in the data structure
    integer, intent(out), optional :: origin
 
+   integer :: info
    character(:, tfc), pointer :: dummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = dummy
-      if (present(stat)) stat = toml_stat%success
+      info = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      info = toml_stat%type_mismatch
    end if
 
+   if (present(stat)) stat = info
    if (present(origin)) origin = self%origin_value
 end subroutine get_value_string
 

--- a/src/tomlf/build/keyval.f90
+++ b/src/tomlf/build/keyval.f90
@@ -82,13 +82,24 @@ subroutine get_value_float_sp(self, val, stat, origin)
    integer, intent(out), optional :: origin
 
    real(tfr), pointer :: dummy
+   integer(tfi), pointer :: idummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = real(dummy, tf_sp)
       if (present(stat)) stat = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      call self%get(idummy)
+      if (associated(idummy)) then
+         val = real(idummy, tf_sp)
+         if (nint(val, tfi) == idummy) then
+            if (present(stat)) stat = toml_stat%success
+         else
+            if (present(stat)) stat = toml_stat%conversion_error
+         end if
+      else
+         if (present(stat)) stat = toml_stat%type_mismatch
+      end if
    end if
 
    if (present(origin)) origin = self%origin_value
@@ -111,13 +122,24 @@ subroutine get_value_float_dp(self, val, stat, origin)
    integer, intent(out), optional :: origin
 
    real(tfr), pointer :: dummy
+   integer(tfi), pointer :: idummy
 
    call self%get(dummy)
    if (associated(dummy)) then
       val = real(dummy, tf_dp)
       if (present(stat)) stat = toml_stat%success
    else
-      if (present(stat)) stat = toml_stat%type_mismatch
+      call self%get(idummy)
+      if (associated(idummy)) then
+         val = real(idummy, tf_dp)
+         if (nint(val, tfi) == idummy) then
+            if (present(stat)) stat = toml_stat%success
+         else
+            if (present(stat)) stat = toml_stat%conversion_error
+         end if
+      else
+         if (present(stat)) stat = toml_stat%type_mismatch
+      end if
    end if
 
    if (present(origin)) origin = self%origin_value
@@ -144,7 +166,11 @@ subroutine get_value_integer_i1(self, val, stat, origin)
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i1)
-      if (present(stat)) stat = toml_stat%success
+      if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
+         if (present(stat)) stat = toml_stat%success
+      else
+         if (present(stat)) stat = toml_stat%conversion_error
+      end if
    else
       if (present(stat)) stat = toml_stat%type_mismatch
    end if
@@ -173,7 +199,11 @@ subroutine get_value_integer_i2(self, val, stat, origin)
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i2)
-      if (present(stat)) stat = toml_stat%success
+      if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
+         if (present(stat)) stat = toml_stat%success
+      else
+         if (present(stat)) stat = toml_stat%conversion_error
+      end if
    else
       if (present(stat)) stat = toml_stat%type_mismatch
    end if
@@ -202,7 +232,11 @@ subroutine get_value_integer_i4(self, val, stat, origin)
    call self%get(dummy)
    if (associated(dummy)) then
       val = int(dummy, tf_i4)
-      if (present(stat)) stat = toml_stat%success
+      if (dummy <= huge(val) .and. dummy >= -huge(val)-1) then
+         if (present(stat)) stat = toml_stat%success
+      else
+         if (present(stat)) stat = toml_stat%conversion_error
+      end if
    else
       if (present(stat)) stat = toml_stat%type_mismatch
    end if

--- a/src/tomlf/error.f90
+++ b/src/tomlf/error.f90
@@ -37,6 +37,9 @@ module tomlf_error
       !> Incorrect type when reading a value
       integer :: type_mismatch = -3
 
+      !> Conversion error when downcasting a value
+      integer :: conversion_error = -4
+
    end type enum_stat
 
    !> Actual enumerator for return states

--- a/test/unit/build.f90
+++ b/test/unit/build.f90
@@ -60,7 +60,7 @@ end subroutine collect_build
 
 !> Check double precision floating point numbers (default)
 subroutine table_real_dp(error)
-   use tomlf_constants, only : tf_dp
+   use tomlf_constants, only : tf_dp, tfi
    use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
@@ -99,15 +99,27 @@ subroutine table_real_dp(error)
    call check(error, val, in3)
    if (allocated(error)) return
 
+   call set_value(table, "int", huge(1_tfi), stat=stat)
+   call get_value(table, "int", val, stat=stat)
+
+   call check(error, stat, toml_stat%conversion_error)
+   if (allocated(error)) return
+
+   call set_value(table, "int", 1_tfi, stat=stat)
+   call get_value(table, "int", val, stat=stat)
+
+   call check(error, val, 1.0_tf_dp)
+   if (allocated(error)) return
+
 end subroutine table_real_dp
 
 
 !> Check single precision floating point numbers
-!
-!  Since TOML requires to store them as double precision numbers, we might find
-!  larger deviations here than just epsilon.
+!>
+!> Since TOML requires to store them as double precision numbers, we might find
+!> larger deviations here than just epsilon.
 subroutine table_real_sp(error)
-   use tomlf_constants, only : tf_sp
+   use tomlf_constants, only : tf_sp, tfi
    use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
@@ -147,12 +159,24 @@ subroutine table_real_sp(error)
    call check(error, val, in3)
    if (allocated(error)) return
 
+   call set_value(table, "int", huge(1_tfi), stat=stat)
+   call get_value(table, "int", val, stat=stat)
+
+   call check(error, stat, toml_stat%conversion_error)
+   if (allocated(error)) return
+
+   call set_value(table, "int", 1_tfi, stat=stat)
+   call get_value(table, "int", val, stat=stat)
+
+   call check(error, val, 1.0_tf_sp)
+   if (allocated(error)) return
+
 end subroutine table_real_sp
 
 
 !> Check smallest integers (char)
 subroutine table_int_i1(error)
-   use tomlf_constants, only : tf_i1
+   use tomlf_constants, only : tf_i1, tfi
    use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
@@ -191,12 +215,18 @@ subroutine table_int_i1(error)
    call check(error, val, in3)
    if (allocated(error)) return
 
+   call set_value(table, "huge", huge(1_tfi), stat=stat)
+   call get_value(table, "huge", val, stat=stat)
+
+   call check(error, stat, toml_stat%conversion_error)
+   if (allocated(error)) return
+
 end subroutine table_int_i1
 
 
 !> Check short integers
 subroutine table_int_i2(error)
-   use tomlf_constants, only : tf_i2
+   use tomlf_constants, only : tf_i2, tfi
    use tomlf_type, only : new_table, toml_table
 
    !> Error handling
@@ -235,12 +265,18 @@ subroutine table_int_i2(error)
    call check(error, val, in3)
    if (allocated(error)) return
 
+   call set_value(table, "huge", huge(1_tfi), stat=stat)
+   call get_value(table, "huge", val, stat=stat)
+
+   call check(error, stat, toml_stat%conversion_error)
+   if (allocated(error)) return
+
 end subroutine table_int_i2
 
 
 !> Check default integers
 subroutine table_int_i4(error)
-   use tomlf_constants, only : tf_i4
+   use tomlf_constants, only : tf_i4, tfi
    use tomlf_type, only : new_table, toml_table, toml_key
 
    !> Error handling
@@ -277,6 +313,12 @@ subroutine table_int_i4(error)
    call get_value(table, "int", val, in3, stat=stat)
 
    call check(error, val, in3)
+   if (allocated(error)) return
+
+   call set_value(table, "huge", huge(1_tfi), stat=stat)
+   call get_value(table, "huge", val, stat=stat)
+
+   call check(error, stat, toml_stat%conversion_error)
    if (allocated(error)) return
 
 end subroutine table_int_i4
@@ -541,6 +583,7 @@ subroutine array_real_sp(error)
 
    type(toml_array) :: array
    real(tf_sp) :: val
+   real(tf_sp), allocatable :: vals(:)
    integer :: ii
    integer :: stat
 
@@ -556,6 +599,20 @@ subroutine array_real_sp(error)
    call check(error, val, sqrt(7.0_tf_sp), rel=.true.)
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(7), val, rel=.true.)
+   if (allocated(error)) return
+
+   vals = 2*vals(:9)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), 9)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, 2*sqrt(7.0_tf_sp), rel=.true.)
+   if (allocated(error)) return
+
 end subroutine array_real_sp
 
 
@@ -569,6 +626,7 @@ subroutine array_real_dp(error)
 
    type(toml_array) :: array
    real(tf_dp) :: val
+   real(tf_dp), allocatable :: vals(:)
    integer :: ii
    integer :: stat
 
@@ -584,6 +642,20 @@ subroutine array_real_dp(error)
    call check(error, val, sqrt(7.0_tf_dp), rel=.true.)
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(7), val, rel=.true.)
+   if (allocated(error)) return
+
+   vals = 2*vals(:9)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), 9)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, 2*sqrt(7.0_tf_dp), rel=.true.)
+   if (allocated(error)) return
+
 end subroutine array_real_dp
 
 
@@ -597,6 +669,7 @@ subroutine array_int_i1(error)
 
    type(toml_array) :: array
    integer(tf_i1) :: val
+   integer(tf_i1), allocatable :: vals(:)
    integer(tf_i1), parameter :: ref(4) = [integer(tf_i1) :: 1, 3, 5, 7]
    integer :: ii
    integer :: stat
@@ -613,6 +686,20 @@ subroutine array_int_i1(error)
    call check(error, val, ref(ii))
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(ii), val)
+   if (allocated(error)) return
+
+   vals = -vals(:ii)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), ii)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, -ref(ii))
+   if (allocated(error)) return
+
 end subroutine array_int_i1
 
 
@@ -626,6 +713,7 @@ subroutine array_int_i2(error)
 
    type(toml_array) :: array
    integer(tf_i2) :: val
+   integer(tf_i2), allocatable :: vals(:)
    integer(tf_i2), parameter :: ref(4) = [integer(tf_i2) :: 1, 3, 5, 7]
    integer :: ii
    integer :: stat
@@ -642,6 +730,20 @@ subroutine array_int_i2(error)
    call check(error, val, ref(ii))
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(ii), val)
+   if (allocated(error)) return
+
+   vals = -vals(:ii)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), ii)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, -ref(ii))
+   if (allocated(error)) return
+
 end subroutine array_int_i2
 
 
@@ -655,6 +757,7 @@ subroutine array_int_i4(error)
 
    type(toml_array) :: array
    integer(tf_i4) :: val
+   integer(tf_i4), allocatable :: vals(:)
    integer(tf_i4), parameter :: ref(4) = [integer(tf_i4) :: 1, 3, 5, 7]
    integer :: ii
    integer :: stat
@@ -671,6 +774,20 @@ subroutine array_int_i4(error)
    call check(error, val, ref(ii))
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(ii), val)
+   if (allocated(error)) return
+
+   vals = -vals(:ii)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), ii)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, -ref(ii))
+   if (allocated(error)) return
+
 end subroutine array_int_i4
 
 
@@ -684,6 +801,7 @@ subroutine array_int_i8(error)
 
    type(toml_array) :: array
    integer(tf_i8) :: val
+   integer(tf_i8), allocatable :: vals(:)
    integer(tf_i8), parameter :: ref(4) = [integer(tf_i8) :: 1, 3, 5, 7]
    integer :: ii
    integer :: stat
@@ -700,6 +818,20 @@ subroutine array_int_i8(error)
    call check(error, val, ref(ii))
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(ii), val)
+   if (allocated(error)) return
+
+   vals = -vals(:ii)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), ii)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, -ref(ii))
+   if (allocated(error)) return
+
 end subroutine array_int_i8
 
 
@@ -712,6 +844,7 @@ subroutine array_bool(error)
 
    type(toml_array) :: array
    logical :: val
+   logical, allocatable :: vals(:)
    integer :: ii
    integer :: stat
 
@@ -727,6 +860,20 @@ subroutine array_bool(error)
    call check(error, val, mod(ii, 2) == 1)
    if (allocated(error)) return
 
+   call get_value(array, vals, stat=stat)
+   call check(error, allocated(vals))
+   call check(error, vals(7), val)
+   if (allocated(error)) return
+
+   vals = .not.vals(:9)
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), 9)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val, mod(ii, 2) /= 1)
+   if (allocated(error)) return
+
 end subroutine array_bool
 
 
@@ -740,6 +887,7 @@ subroutine array_datetime(error)
 
    type(toml_array) :: array
    type(toml_datetime) :: val, ts
+   type(toml_datetime), allocatable :: vals(:)
    integer :: ii
    integer :: stat
 
@@ -755,6 +903,21 @@ subroutine array_datetime(error)
    ts = toml_datetime(toml_date(2022, ii, 7), toml_time())
    call check(error, val == ts, &
       & "Expected '"//to_string(ts)//"' but got '"//to_string(val)//"'")
+   if (allocated(error)) return
+
+   call get_value(array, vals, stat=stat)
+   call check(error, vals(ii) == val, &
+      & "Expected '"//to_string(val)//"' but got '"//to_string(vals(ii))//"'")
+   if (allocated(error)) return
+
+   vals = [(toml_datetime(toml_date(2022, ii, 8), toml_time()), ii = 1, 9)]
+   call set_value(array, vals, stat=stat)
+   call check(error, len(array), 9)
+   if (allocated(error)) return
+
+   call get_value(array, ii, val, stat=stat)
+   call check(error, val == vals(ii), &
+      & "Expected '"//to_string(vals(ii))//"' but got '"//to_string(val)//"'")
    if (allocated(error)) return
 
 end subroutine array_datetime

--- a/test/unit/build.f90
+++ b/test/unit/build.f90
@@ -111,6 +111,12 @@ subroutine table_real_dp(error)
    call check(error, val, 1.0_tf_dp)
    if (allocated(error)) return
 
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
+   if (allocated(error)) return
+
 end subroutine table_real_dp
 
 
@@ -171,6 +177,12 @@ subroutine table_real_sp(error)
    call check(error, val, 1.0_tf_sp)
    if (allocated(error)) return
 
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
+   if (allocated(error)) return
+
 end subroutine table_real_sp
 
 
@@ -219,6 +231,12 @@ subroutine table_int_i1(error)
    call get_value(table, "huge", val, stat=stat)
 
    call check(error, stat, toml_stat%conversion_error)
+   if (allocated(error)) return
+
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
    if (allocated(error)) return
 
 end subroutine table_int_i1
@@ -271,6 +289,12 @@ subroutine table_int_i2(error)
    call check(error, stat, toml_stat%conversion_error)
    if (allocated(error)) return
 
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
+   if (allocated(error)) return
+
 end subroutine table_int_i2
 
 
@@ -321,6 +345,12 @@ subroutine table_int_i4(error)
    call check(error, stat, toml_stat%conversion_error)
    if (allocated(error)) return
 
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
+   if (allocated(error)) return
+
 end subroutine table_int_i4
 
 
@@ -365,6 +395,12 @@ subroutine table_int_i8(error)
    call check(error, val, in3)
    if (allocated(error)) return
 
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
+   if (allocated(error)) return
+
 end subroutine table_int_i8
 
 
@@ -406,6 +442,12 @@ subroutine table_bool(error)
    call get_value(table, "logic", val, true, stat=stat)
 
    call check(error, val, true)
+   if (allocated(error)) return
+
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
    if (allocated(error)) return
 
 end subroutine table_bool
@@ -456,6 +498,12 @@ subroutine table_datetime(error)
 
    call check(error, val == ts1, &
       & "Expected '"//to_string(ts1)//"' but got '"//to_string(val)//"'")
+   if (allocated(error)) return
+
+   call set_value(table, "str", "1", stat=stat)
+   call get_value(table, "str", val, stat=stat)
+
+   call check(error, stat, toml_stat%type_mismatch)
    if (allocated(error)) return
 
 end subroutine table_datetime


### PR DESCRIPTION
- [x] add `get_value(array, val, stat)` procedures to retrieve the array content as 1D array in `val`
- [x] add `set_value` procedures for adding a whole array
- [x] document array getter / setter in recipe section

Closes #71 