### PR TITLE
Update fpm manifest to enforce module naming

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -13,6 +13,7 @@ source-dir = "src"
 
 [build]
 auto-tests = false
+module-naming = "tomlf"
 
 [[test]]
 name = "tftest"


### PR DESCRIPTION
This commit adds a suitable `module-naming` convention to the fpm manifest for toml-f.  Because toml-f already enforces a valid unique naming (`module tomlf_*`), there is no need to modify any of the source files.  The current commit explicitly adds the naming convention in place to the manifest.

When module names become enforced by default in fpm, this flag will be necessary to build fpm from fpm.