### PR TITLE
Refactor serialization of TOML data

### DIFF
--- a/doc/how-to/jonquil/app/main.f90
+++ b/doc/how-to/jonquil/app/main.f90
@@ -24,12 +24,11 @@ program demo
   end if
 
   block
-    use tomlf, only : toml_table, toml_array, add_array, set_value, toml_serializer
+    use tomlf, only : toml_table, toml_array, add_array, set_value, toml_serialize
 
     integer :: it
     type(toml_table), pointer :: table
     type(toml_array), pointer :: array
-    type(toml_serializer) :: ser
 
     ! Add an array to the object
     call add_array(object, "c", array)
@@ -40,7 +39,7 @@ program demo
     call set_value(table, "sub", "table")
 
     print '(a)', "# representation in TOML land"
-    call object%accept(ser)
+    print '(a)', toml_serialize(object)
   end block
 
 end program demo

--- a/doc/how-to/serde/src/serde_class.f90
+++ b/doc/how-to/serde/src/serde_class.f90
@@ -2,7 +2,7 @@
 !> Each data record knows how to serialize and deserialize itself.
 module serde_class
   use serde_error, only : error_type, fatal_error
-  use tomlf, only : toml_table, toml_error, toml_load, toml_serializer
+  use tomlf, only : toml_table, toml_error, toml_load, toml_dump
   implicit none
   private
 
@@ -130,14 +130,14 @@ contains
     type(error_type), allocatable, intent(out) :: error
 
     type(toml_table) :: table
-    type(toml_serializer) :: ser
 
     table = toml_table()
-    ser = toml_serializer(unit)
 
     call self%dump(table, error)
 
-    call table%accept(ser)
+    if (.not.allocated(error)) then
+      call toml_dump(table, unit, error)
+    end if
 
   end subroutine dump_to_unit
 

--- a/doc/tutorial/getting-started.rst
+++ b/doc/tutorial/getting-started.rst
@@ -39,12 +39,10 @@ Convince yourself that the empty table indeed changed while reading by passing a
 .. code-block:: fortran
 
    block
-     use tomlf, only : toml_serializer
-     type(toml_serializer) :: ser
+     use tomlf, only : toml_serialize
 
      print '(a)', "# Final TOML data structure"
-     ser = toml_serializer()
-     call table%accept(ser)
+     print '(a)', toml_serialize(table)
    end block
    ! Expected output:
    ! # Final TOML data structure

--- a/src/tomlf.f90
+++ b/src/tomlf.f90
@@ -18,7 +18,7 @@ module tomlf
    use tomlf_de, only : toml_parse, toml_load, toml_loads, &
       & toml_context, toml_parser_config, toml_level
    use tomlf_error, only : toml_error, toml_stat
-   use tomlf_ser, only : toml_serializer
+   use tomlf_ser, only : toml_serializer, toml_serialize, toml_dump, toml_dumps
    use tomlf_terminal, only : toml_terminal
    use tomlf_type, only : toml_table, toml_array, toml_keyval, toml_key, toml_value, &
       & is_array_of_tables, new_table, add_table, add_array, add_keyval, len

--- a/src/tomlf/ser.f90
+++ b/src/tomlf/ser.f90
@@ -15,6 +15,7 @@
 module tomlf_ser
    use tomlf_constants, only : tfc, tfi, tfr, tfout, toml_type
    use tomlf_datetime, only : toml_datetime, to_string
+   use tomlf_error, only : toml_error, toml_stat, make_error
    use tomlf_type, only : toml_value, toml_visitor, toml_key, toml_table, &
       & toml_array, toml_keyval, is_array_of_tables, len
    use tomlf_utils, only : to_string, toml_escape_string
@@ -22,13 +23,37 @@ module tomlf_ser
    private
 
    public :: toml_serializer, new_serializer, new
+   public :: toml_dump, toml_dumps, toml_serialize
+
+
+   interface toml_dumps
+      module procedure :: toml_dump_to_string
+   end interface toml_dumps
+
+   interface toml_dump
+      module procedure :: toml_dump_to_file
+      module procedure :: toml_dump_to_unit
+   end interface toml_dump
+
+
+   !> Configuration for JSON serializer
+   type :: toml_ser_config
+
+      !> Indentation
+      character(len=:), allocatable :: indent
+
+   end type toml_ser_config
 
 
    !> TOML serializer to produduce a TOML document from a datastructure
    type, extends(toml_visitor) :: toml_serializer
+      private
 
-      !> Unit for output
-      integer :: unit = tfout
+      !> Output string
+      character(:), allocatable :: output
+
+      !> Configuration for serializer
+      type(toml_ser_config) :: config = toml_ser_config()
 
       !> Special mode for printing array of tables
       logical, private :: array_of_tables = .false.
@@ -69,33 +94,136 @@ module tomlf_ser
 contains
 
 
+!> Serialize a JSON value to a string and return it.
+!>
+!> In case of an error this function will invoke an error stop.
+function toml_serialize(val, config) result(string)
+   !> TOML value to visit
+   class(toml_value), intent(inout) :: val
+
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
+
+   !> Serialized JSON value
+   character(len=:), allocatable :: string
+
+   type(toml_error), allocatable :: error
+
+   call toml_dumps(val, string, error, config=config)
+   if (allocated(error)) then
+      error stop error%message
+   end if
+end function toml_serialize
+
+
+!> Create a string representing the JSON value
+subroutine toml_dump_to_string(val, string, error, config)
+
+   !> TOML value to visit
+   class(toml_value), intent(inout) :: val
+
+   !> Formatted unit to write to
+   character(:), allocatable, intent(out) :: string
+
+   !> Error handling
+   type(toml_error), allocatable, intent(out) :: error
+
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
+
+   type(toml_serializer) :: ser
+
+   ser = toml_serializer(config=config)
+   call val%accept(ser)
+   string = ser%output
+end subroutine toml_dump_to_string
+
+
+!> Write string representation of JSON value to a connected formatted unit
+subroutine toml_dump_to_unit(val, io, error, config)
+
+   !> TOML value to visit
+   class(toml_value), intent(inout) :: val
+
+   !> Formatted unit to write to
+   integer, intent(in) :: io
+
+   !> Error handling
+   type(toml_error), allocatable, intent(out) :: error
+
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
+
+   character(len=:), allocatable :: string
+   character(512) :: msg
+   integer :: stat
+
+   call toml_dumps(val, string, error, config=config)
+   if (allocated(error)) return
+   write(io, '(a)', iostat=stat, iomsg=msg) string
+   if (stat /= 0) then
+      call make_error(error, trim(msg))
+      return
+   end if
+end subroutine toml_dump_to_unit
+
+
+!> Write string representation of JSON value to a file
+subroutine toml_dump_to_file(val, filename, error, config)
+
+   !> TOML value to visit
+   class(toml_value), intent(inout) :: val
+
+   !> File name to write to
+   character(*), intent(in) :: filename
+
+   !> Error handling
+   type(toml_error), allocatable, intent(out) :: error
+
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
+
+   integer :: io
+   integer :: stat
+   character(512) :: msg
+
+   open(file=filename, newunit=io, iostat=stat, iomsg=msg)
+   if (stat /= 0) then
+      call make_error(error, trim(msg))
+      return
+   end if
+   call toml_dump(val, io, error, config=config)
+   close(unit=io, iostat=stat, iomsg=msg)
+   if (.not.allocated(error) .and. stat /= 0) then
+      call make_error(error, trim(msg))
+   end if
+end subroutine toml_dump_to_file
+
+
 !> Constructor to create new serializer instance
-subroutine new_serializer(self, unit)
+subroutine new_serializer(self, config)
 
    !> Instance of the TOML serializer
    type(toml_serializer), intent(out) :: self
 
-   !> Unit for IO
-   integer, intent(in), optional :: unit
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
 
-   if (present(unit)) then
-      self%unit = unit
-   end if
-
+   self%output = ""
+   if (present(config)) self%config = config
 end subroutine new_serializer
 
 
 !> Default constructor for TOML serializer
-function new_serializer_func(unit) result(self)
+function new_serializer_func(config) result(self)
 
-   !> Unit for IO
-   integer, intent(in), optional :: unit
+   !> Configuration for serializer
+   type(toml_ser_config), intent(in), optional :: config
 
    !> Instance of the TOML serializer
    type(toml_serializer) :: self
 
-   call new_serializer(self, unit)
-
+   call new_serializer(self, config)
 end function new_serializer_func
 
 
@@ -161,10 +289,11 @@ subroutine visit_keyval(visitor, keyval)
    end select
 
    if (visitor%inline_array) then
-      write(visitor%unit, '(1x,a,1x,"=",1x,a)', advance='no') &
-         &  key, str
-   else
-      write(visitor%unit, '(a,1x,"=",1x,a)') key, str
+      visitor%output = visitor%output // " "
+   end if
+   visitor%output = visitor%output // key // " = " // str
+   if (.not.visitor%inline_array) then
+      visitor%output = visitor%output // new_line('a')
    end if
 
 end subroutine visit_keyval
@@ -188,7 +317,7 @@ recursive subroutine visit_array(visitor, array)
    logical, pointer :: lval
    integer :: i, n
 
-   if (visitor%inline_array) write(visitor%unit, '(1x,"[")', advance='no')
+   if (visitor%inline_array) visitor%output = visitor%output // " ["
    n = len(array)
    do i = 1, n
       call array%get(i, ptr)
@@ -217,17 +346,17 @@ recursive subroutine visit_array(visitor, array)
             str = to_string(dval)
          end select
 
-         write(visitor%unit, '(1x,a)', advance='no') str
-         if (i /= n) write(visitor%unit, '(",")', advance='no')
+         visitor%output = visitor%output // " " // str
+         if (i /= n) visitor%output = visitor%output // ","
       class is(toml_array)
          call ptr%accept(visitor)
-         if (i /= n) write(visitor%unit, '(",")', advance='no')
+         if (i /= n) visitor%output = visitor%output // ","
       class is(toml_table)
          if (visitor%inline_array) then
-            write(visitor%unit, '(1x,"{")', advance='no')
+            visitor%output = visitor%output // " {"
             call ptr%accept(visitor)
-            write(visitor%unit, '(1x,"}")', advance='no')
-            if (i /= n) write(visitor%unit, '(",")', advance='no')
+            visitor%output = visitor%output // " }"
+            if (i /= n) visitor%output = visitor%output // ","
          else
             visitor%array_of_tables = .true.
             if (size(visitor%stack, 1) <= visitor%top) call resize(visitor%stack)
@@ -240,7 +369,7 @@ recursive subroutine visit_array(visitor, array)
          end if
       end select
    end do
-   if (visitor%inline_array) write(visitor%unit, '(1x,"]")', advance='no')
+   if (visitor%inline_array) visitor%output = visitor%output // " ]"
 
 end subroutine visit_array
 
@@ -269,15 +398,15 @@ recursive subroutine visit_table(visitor, table)
       call resize(visitor%stack)
    else
       if (.not.(visitor%inline_array .or. table%implicit)) then
-         write(visitor%unit, '("[")', advance='no')
-         if (visitor%array_of_tables) write(visitor%unit, '("[")', advance='no')
+         visitor%output = visitor%output // "["
+         if (visitor%array_of_tables) visitor%output = visitor%output // "["
          do i = 1, visitor%top-1
-            write(visitor%unit, '(a,".")', advance='no') visitor%stack(i)%key
+            visitor%output = visitor%output // visitor%stack(i)%key // "."
          end do
-         write(visitor%unit, '(a)', advance='no') visitor%stack(visitor%top)%key
-         write(visitor%unit, '("]")', advance='no')
-         if (visitor%array_of_tables) write(visitor%unit, '("]")', advance='no')
-         write(visitor%unit, '(a)')
+         visitor%output = visitor%output // visitor%stack(visitor%top)%key
+         visitor%output = visitor%output // "]"
+         if (visitor%array_of_tables) visitor%output = visitor%output // "]"
+         visitor%output = visitor%output // new_line('a')
          visitor%array_of_tables = .false.
       end if
    end if
@@ -289,14 +418,14 @@ recursive subroutine visit_table(visitor, table)
       class is(toml_keyval)
          call ptr%accept(visitor)
          if (visitor%inline_array) then
-            if (i /= n) write(visitor%unit, '(",")', advance='no')
+            if (i /= n) visitor%output = visitor%output // ","
          end if
       class is(toml_array)
          if (visitor%inline_array) then
             call ptr%get_key(key)
-            write(visitor%unit, '(1x,a,1x,"=")', advance='no') key
+            visitor%output = visitor%output // " " // key // " ="
             call ptr%accept(visitor)
-            if (i /= n) write(visitor%unit, '(",")', advance='no')
+            if (i /= n) visitor%output = visitor%output // ","
          else
             if (is_array_of_tables(ptr)) then
                ! Array of tables open a new section
@@ -305,10 +434,10 @@ recursive subroutine visit_table(visitor, table)
             else
                visitor%inline_array = .true.
                call ptr%get_key(key)
-               write(visitor%unit, '(a,1x,"=")', advance='no') key
+               visitor%output = visitor%output // key // " ="
                call ptr%accept(visitor)
                visitor%inline_array = .false.
-               write(visitor%unit, '(a)')
+               visitor%output = visitor%output // new_line('a')
             end if
          end if
       class is(toml_table)
@@ -325,24 +454,24 @@ recursive subroutine visit_table(visitor, table)
          class is(toml_keyval)
             call ptr%accept(visitor)
             if (visitor%inline_array) then
-               if (i /= n) write(visitor%unit, '(",")', advance='no')
+               if (i /= n) visitor%output = visitor%output // ","
             end if
          class is(toml_array)
             if (visitor%inline_array) then
                call ptr%get_key(key)
-               write(visitor%unit, '(1x,a,1x,"=")', advance='no') key
+               visitor%output = visitor%output // " " // key // " ="
                call ptr%accept(visitor)
-               if (i /= n) write(visitor%unit, '(",")', advance='no')
+               if (i /= n) visitor%output = visitor%output // ","
             else
                if (is_array_of_tables(ptr)) then
                   call ptr%accept(visitor)
                else
                   visitor%inline_array = .true.
                   call ptr%get_key(key)
-                  write(visitor%unit, '(a,1x,"=")', advance='no') key
+                  visitor%output = visitor%output // key // " ="
                   call ptr%accept(visitor)
                   visitor%inline_array = .false.
-                  write(visitor%unit, '(a)')
+                  visitor%output = visitor%output // new_line('a')
                end if
             end if
          class is(toml_table)

--- a/test/compliance/json2toml.f90
+++ b/test/compliance/json2toml.f90
@@ -13,7 +13,7 @@
 
 !> Example executable to read and emit a TOML document
 program json2toml
-   use, intrinsic :: iso_fortran_env, only : input_unit
+   use, intrinsic :: iso_fortran_env, only : input_unit, output_unit
    use tomlf
    use tjson_parser
    implicit none
@@ -21,7 +21,6 @@ program json2toml
    character(len=:), allocatable :: argument
    class(toml_value), allocatable :: object
    type(toml_error), allocatable :: error
-   type(toml_serializer) :: ser
    logical :: exist
 
    if (command_argument_count() > 0) then
@@ -39,7 +38,7 @@ program json2toml
             call json_load(object, argument, error=error)
             if (allocated(error)) print '(a)', error%message
             if (allocated(object)) then
-               call object%accept(ser)
+               call toml_dump(object, output_unit, error)
                call object%destroy
             end if
          end if
@@ -48,7 +47,7 @@ program json2toml
       call json_load(object, input_unit, error=error)
       if (allocated(error)) print '(a)', error%message
       if (allocated(object)) then
-         call object%accept(ser)
+         call toml_dump(object, output_unit, error)
          call object%destroy
       else
          error stop


### PR DESCRIPTION
*Note*: Breaking change of `toml_serializer` API

- [x] `toml_dump` subroutine to write to a file or unit
- [x] `toml_dumps` subroutine to write to a string
- [x] `toml_serialize` function to return string