### PR TITLE
Support nil tokens in parser

### DIFF
--- a/doc/tutorial/json.rst
+++ b/doc/tutorial/json.rst
@@ -128,7 +128,7 @@ We use a select case statement to decide which token to produce.
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (next_token, continued)
-   :lines: 182-224
+   :lines: 182-227
 
 To wrap up the lexing we will try to identify unknown tokens as well as possible trying to advance to the next terminating character.
 For the terminating characters, we choose whitespace as well as control characters and place those in the module scope.
@@ -152,28 +152,35 @@ While doing so we can also ensure that the escape sequences found are valid and 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (next_string)
-   :lines: 226-264
+   :lines: 229-267
 
 Strings can only contain printable characters, therefore we check for valid string characters using a small *valid_string* function for each character.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (valid_string)
-   :lines: 353-365
+   :lines: 377-389
 
 We also need to identify numbers, mapping to either integers or floats in TOML, which is done via *next_number*.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (next_number)
-   :lines: 266-327
+   :lines: 269-330
 
 To support boolean values we implement a *next_boolean* procedure.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (next_boolean)
-   :lines: 329-351
+   :lines: 332-354
+
+Finally, we also want to parse null values using the *next_null* procedure.
+
+.. literalinclude:: ../../test/compliance/json_lexer.f90
+   :language: fortran
+   :caption: src/json_lexer.f90 (next_null)
+   :lines: 356-375
 
 With this logic available we can now generate all required tokens for parsing JSON.
 
@@ -193,6 +200,7 @@ This will direct the parser to leave the root document where newlines are semant
 
 .. admonition:: Exercise
 
+   The *nil* token will make the parser skip the respective value.
    If we want to support *null* values, how would we have to modify our lexer to produce for example an empty table ``{}`` instead, *i.e.* a *lbrace* and *rbrace* token?
 
 
@@ -208,35 +216,35 @@ We will also use the *extract_string* routine to catch the *keypath* token we in
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (extract_string)
-   :lines: 367-406
+   :lines: 391-430
 
 Similarly, we implement the *extract_integer*, instead of using an internal read, we implement the reading ourselves.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (extract_integer)
-   :lines: 408-437
+   :lines: 432-461
 
 For floating point numbers implemented in *extract_float* we will just use an internal read.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (extract_float)
-   :lines: 439-455
+   :lines: 463-479
 
 The last token we can produce and extract from our lexer is are boolean values, which we implement in *extract_boolean*.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (extract_boolean)
-   :lines: 457-469
+   :lines: 481-493
 
 We create a mocked routine for *extract_datetime* since we cannot produce this token in JSON.
 
 .. literalinclude:: ../../test/compliance/json_lexer.f90
    :language: fortran
    :caption: src/json_lexer.f90 (extract_datetime)
-   :lines: 471-479
+   :lines: 495-506
 
 This provides our lexer with full functionality regarding the extraction of values needed for parsing and creating data structures.
 
@@ -337,7 +345,7 @@ This has the advantage that we can support arrays and values at the root level w
 
 .. dropdown:: full source
 
-   For completeness here is again the full source of our lexer implementation.
+   For completeness here is again the full source of our parser implementation.
 
    Note that this implementation also contains an implementation of a *toml_visitor* to prune type annotations used in the validation test suite to represent TOML values.
 

--- a/src/tomlf/de/parser.f90
+++ b/src/tomlf/de/parser.f90
@@ -482,6 +482,9 @@ recursive subroutine parse_keyval(parser, lexer, table)
       call add_keyval(table, key, vptr)
       call parse_value(parser, lexer, vptr)
 
+   case(token_kind%nil)
+      call next_token(parser, lexer)
+
    case(token_kind%lbracket)
       call add_array(table, key, aptr)
       call parse_inline_array(parser, lexer, aptr)
@@ -529,6 +532,9 @@ recursive subroutine parse_inline_array(parser, lexer, array)
       case default
          call add_keyval(array, vptr)
          call parse_value(parser, lexer, vptr)
+
+      case(token_kind%nil)
+         call next_token(parser, lexer)
 
       case(token_kind%lbracket)
          call add_array(array, aptr)

--- a/src/tomlf/de/token.f90
+++ b/src/tomlf/de/token.f90
@@ -65,6 +65,8 @@ module tomlf_de_token
       integer :: bool = 17
       !> Datetime value
       integer :: datetime = 18
+      !> Absence of value
+      integer :: nil = 19
    end type enum_token
 
    !> Actual enumerator for token kinds

--- a/test/compliance/json_lexer.f90
+++ b/test/compliance/json_lexer.f90
@@ -211,6 +211,9 @@ subroutine next_token(lexer, token)
    case("t", "f")
       call next_boolean(lexer, token)
       return
+   case("n")
+      call next_null(lexer, token)
+      return
    case(",")
       token = toml_token(token_kind%comma, prev, pos)
       return
@@ -349,6 +352,27 @@ subroutine next_boolean(lexer, token)
       token = toml_token(token_kind%bool, prev, pos)
    end select
 end subroutine next_boolean
+
+!> Process next null token
+subroutine next_null(lexer, token)
+   !> Instance of the lexer
+   type(json_lexer), intent(inout) :: lexer
+   !> Current token
+   type(toml_token), intent(inout) :: token
+
+   integer :: pos, prev
+
+   prev = lexer%pos
+   pos = lexer%pos
+
+   do while(verify(lexer%chunk(pos+1:pos+1), terminated) > 0 .and. pos < len(lexer%chunk))
+      pos = pos + 1
+   end do
+
+   token = toml_token( &
+      & merge(token_kind%nil, token_kind%invalid, lexer%chunk(prev:pos) == "null"), &
+      & prev, pos)
+end subroutine next_null
 
 !> Validate characters in string, non-printable characters are invalid in this context
 pure function valid_string(ch) result(valid)


### PR DESCRIPTION
- lexer can generate nil tokens
- values with nil tokens ignored in arrays and key-value pairs

Closes #126 