### PR TITLE
Remove CI with GCC 6

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -12,9 +12,6 @@ jobs:
         build-type: [default]
 
         include:
-          - os: macos-latest
-            toolchain: {compiler: gcc, version: 6}
-            build-type: default
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 9}
             build-type: coverage


### PR DESCRIPTION
GCC 6 is not available anymore for MacOS runner