### PR TITLE
Bugfix for patch versions of CMake 3.18

### DIFF
--- a/test/version/CMakeLists.txt
+++ b/test/version/CMakeLists.txt
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.18")
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
   # Required for policy change
   cmake_policy(SET CMP0110 NEW)
 endif()

--- a/test/version/CMakeLists.txt
+++ b/test/version/CMakeLists.txt
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
+if(POLICY CMP0110)
   # Required for policy change
   cmake_policy(SET CMP0110 NEW)
 endif()


### PR DESCRIPTION
- In CMakeLists.txt inside test/version the line if(${CMAKE_VERSION} VERSION_GREATER "3.18") would be entered by patch versions of CMake 3.18 (e.g. 3.18.1). The policy CMP0110 would then be attempted to be applied, even though it was only introduced in CMake version 3.19, and then compilation would fail.
- The one-liner fixes this problem
- For issue #150