### PR TITLE
Modify the stop error call to be Fortran2008 compliant

### DIFF
--- a/src/tomlf/ser.f90
+++ b/src/tomlf/ser.f90
@@ -111,7 +111,8 @@ function toml_serialize(val, config) result(string)
 
    call toml_dumps(val, string, error, config=config)
    if (allocated(error)) then
-      error stop error%message
+      print '(a)', "Error: " // error%message
+      error stop 1
    end if
 end function toml_serialize
 


### PR DESCRIPTION
This merge request fixes #153, but modifying the `error stop` call in `src/tomlf/ser.f90` to be Fortran2008 compliant.
I've written the error message in a similar way to the tutorial: https://toml-f.readthedocs.io/en/latest/tutorial/getting-started.html, for stylistic consistency. 