### PR TITLE
Changed intent(inout) to intent(in): `get` and `get_keys`

### DIFF
--- a/src/tomlf/build/array.f90
+++ b/src/tomlf/build/array.f90
@@ -102,7 +102,7 @@ contains
 subroutine get_elem_table(array, pos, ptr, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -117,8 +117,6 @@ subroutine get_elem_table(array, pos, ptr, stat, origin)
    integer, intent(out), optional :: origin
 
    class(toml_value), pointer :: tmp
-
-   if (.not.initialized(array)) call new_array(array)
 
    nullify(ptr)
 
@@ -145,7 +143,7 @@ end subroutine get_elem_table
 subroutine get_elem_array(array, pos, ptr, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -160,8 +158,6 @@ subroutine get_elem_array(array, pos, ptr, stat, origin)
    integer, intent(out), optional :: origin
 
    class(toml_value), pointer :: tmp
-
-   if (.not.initialized(array)) call new_array(array)
 
    nullify(ptr)
 
@@ -188,7 +184,7 @@ end subroutine get_elem_array
 subroutine get_elem_keyval(array, pos, ptr, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -203,8 +199,6 @@ subroutine get_elem_keyval(array, pos, ptr, stat, origin)
    integer, intent(out), optional :: origin
 
    class(toml_value), pointer :: tmp
-
-   if (.not.initialized(array)) call new_array(array)
 
    nullify(ptr)
 
@@ -232,7 +226,7 @@ end subroutine get_elem_keyval
 subroutine get_elem_value_string(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -263,7 +257,7 @@ end subroutine get_elem_value_string
 subroutine get_elem_value_float_sp(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -294,7 +288,7 @@ end subroutine get_elem_value_float_sp
 subroutine get_elem_value_float_dp(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -325,7 +319,7 @@ end subroutine get_elem_value_float_dp
 subroutine get_elem_value_int_i1(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -356,7 +350,7 @@ end subroutine get_elem_value_int_i1
 subroutine get_elem_value_int_i2(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -387,7 +381,7 @@ end subroutine get_elem_value_int_i2
 subroutine get_elem_value_int_i4(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -418,7 +412,7 @@ end subroutine get_elem_value_int_i4
 subroutine get_elem_value_int_i8(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -449,7 +443,7 @@ end subroutine get_elem_value_int_i8
 subroutine get_elem_value_bool(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos
@@ -480,7 +474,7 @@ end subroutine get_elem_value_bool
 subroutine get_elem_value_datetime(array, pos, val, stat, origin)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: array
+   class(toml_array), intent(in) :: array
 
    !> Position in the array
    integer, intent(in) :: pos

--- a/src/tomlf/build/path.f90
+++ b/src/tomlf/build/path.f90
@@ -137,7 +137,7 @@ end function new_path4
 subroutine get_path_table(table, path, ptr, requested, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout), target :: table
+   class(toml_table), intent(in), target :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -173,7 +173,7 @@ end subroutine get_path_table
 subroutine get_path_array(table, path, ptr, requested, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -209,7 +209,7 @@ end subroutine get_path_array
 subroutine get_path_keyval(table, path, ptr, requested, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -246,7 +246,7 @@ end subroutine get_path_keyval
 subroutine get_path_value_float_sp(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -276,7 +276,7 @@ end subroutine get_path_value_float_sp
 subroutine get_path_value_float_dp(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -306,7 +306,7 @@ end subroutine get_path_value_float_dp
 subroutine get_path_value_integer_i1(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -336,7 +336,7 @@ end subroutine get_path_value_integer_i1
 subroutine get_path_value_integer_i2(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -366,7 +366,7 @@ end subroutine get_path_value_integer_i2
 subroutine get_path_value_integer_i4(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -396,7 +396,7 @@ end subroutine get_path_value_integer_i4
 subroutine get_path_value_integer_i8(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -426,7 +426,7 @@ end subroutine get_path_value_integer_i8
 subroutine get_path_value_bool(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -456,7 +456,7 @@ end subroutine get_path_value_bool
 subroutine get_path_value_datetime(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -486,7 +486,7 @@ end subroutine get_path_value_datetime
 subroutine get_path_value_string(table, path, val, default, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: table
+   class(toml_table), intent(in) :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path
@@ -758,7 +758,7 @@ end subroutine set_path_value_string
 subroutine walk_path(table, path, ptr, requested, stat, origin)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout), target :: table
+   class(toml_table), intent(in), target :: table
 
    !> Path in this TOML table
    type(toml_path), intent(in) :: path

--- a/src/tomlf/structure/array_list.f90
+++ b/src/tomlf/structure/array_list.f90
@@ -102,7 +102,7 @@ end function get_len
 subroutine get(self, idx, ptr)
 
    !> Instance of the structure
-   class(toml_array_list), intent(inout), target :: self
+   class(toml_array_list), intent(in), target :: self
 
    !> Position in the ordered structure
    integer, intent(in) :: idx

--- a/src/tomlf/structure/list.f90
+++ b/src/tomlf/structure/list.f90
@@ -64,7 +64,7 @@ module tomlf_structure_list
          import :: toml_list_structure, toml_value
 
          !> Instance of the structure
-         class(toml_list_structure), intent(inout), target :: self
+         class(toml_list_structure), intent(in), target :: self
 
          !> Position in the ordered structure
          integer, intent(in) :: idx

--- a/src/tomlf/structure/map.f90
+++ b/src/tomlf/structure/map.f90
@@ -52,7 +52,7 @@ module tomlf_structure_map
          import :: toml_map_structure, toml_value, tfc
 
          !> Instance of the structure
-         class(toml_map_structure), intent(inout), target :: self
+         class(toml_map_structure), intent(in), target :: self
 
          !> Key to the TOML value
          character(kind=tfc, len=*), intent(in) :: key
@@ -80,7 +80,7 @@ module tomlf_structure_map
          import :: toml_map_structure, toml_key
 
          !> Instance of the structure
-         class(toml_map_structure), intent(inout), target :: self
+         class(toml_map_structure), intent(in), target :: self
 
          !> List of all keys
          type(toml_key), allocatable, intent(out) :: list(:)

--- a/src/tomlf/structure/ordered_map.f90
+++ b/src/tomlf/structure/ordered_map.f90
@@ -88,7 +88,7 @@ end subroutine new_ordered_map
 subroutine get(self, key, ptr)
 
    !> Instance of the structure
-   class(toml_ordered_map), intent(inout), target :: self
+   class(toml_ordered_map), intent(in), target :: self
 
    !> Key to the TOML value
    character(kind=tfc, len=*), intent(in) :: key
@@ -142,7 +142,7 @@ end subroutine push_back
 subroutine get_keys(self, list)
 
    !> Instance of the structure
-   class(toml_ordered_map), intent(inout), target :: self
+   class(toml_ordered_map), intent(in), target :: self
 
    !> List of all keys
    type(toml_key), allocatable, intent(out) :: list(:)

--- a/src/tomlf/type/array.f90
+++ b/src/tomlf/type/array.f90
@@ -122,6 +122,12 @@ pure function get_len(self) result(length)
    !> Current length of the array
    integer :: length
 
+   ! If calling get_len return 0 
+   if (.not. array_initialized(self)) then
+      length = 0
+      return
+   end if
+
    length = self%list%get_len()
 
 end function get_len
@@ -131,13 +137,16 @@ end function get_len
 subroutine get(self, idx, ptr)
 
    !> Instance of the TOML array
-   class(toml_array), intent(inout) :: self
+   class(toml_array), intent(in) :: self
 
    !> Index to the TOML value
    integer, intent(in) :: idx
 
    !> Pointer to the TOML value
    class(toml_value), pointer, intent(out) :: ptr
+
+   ! If a empty array
+   if (.not. array_initialized(self)) return 
 
    call self%list%get(idx, ptr)
 
@@ -161,6 +170,11 @@ subroutine push_back(self, val, stat)
       return
    end if
 
+   ! If a empty array
+   if (.not. array_initialized(self)) then
+      call new_array(self)
+   end if
+
    call self%list%push_back(val)
 
    stat = toml_stat%success
@@ -177,6 +191,11 @@ subroutine shift(self, val)
    !> TOML value to be retrieved
    class(toml_value), allocatable, intent(out) :: val
 
+   ! If a empty array
+   if (.not. array_initialized(self)) then
+      call new_array(self)
+   end if
+
    call self%list%shift(val)
 
 end subroutine shift
@@ -190,6 +209,11 @@ subroutine pop(self, val)
 
    !> TOML value to be retrieved
    class(toml_value), allocatable, intent(out) :: val
+
+   ! If a empty array
+   if (.not. array_initialized(self)) then
+      call new_array(self)
+   end if
 
    call self%list%pop(val)
 

--- a/src/tomlf/type/table.f90
+++ b/src/tomlf/type/table.f90
@@ -141,7 +141,7 @@ end subroutine get
 subroutine get_keys(self, list)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: self
+   class(toml_table), intent(in) :: self
 
    !> List of all keys
    type(toml_key), allocatable, intent(out) :: list(:)
@@ -155,7 +155,7 @@ end subroutine get_keys
 function has_key(self, key) result(found)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: self
+   class(toml_table), intent(in) :: self
 
    !> Key to the TOML value
    character(kind=tfc, len=*), intent(in) :: key

--- a/src/tomlf/type/table.f90
+++ b/src/tomlf/type/table.f90
@@ -124,7 +124,7 @@ end function table_initialized
 subroutine get(self, key, ptr)
 
    !> Instance of the TOML table
-   class(toml_table), intent(inout) :: self
+   class(toml_table), intent(in) :: self
 
    !> Key to the TOML value
    character(kind=tfc, len=*), intent(in) :: key


### PR DESCRIPTION
Hi, is there a reason why `get` and `get_keys` are `intent(inout)` ?
Because AFAIK the related functions don't seem to modify the state of the tables and etc...

For context I was trying to load a table that was `intent(in)` and got struck by this error:

```
toml.f90                               failed.
[  2%] Compiling...
././src/utils/toml.f90:104:12:

  104 |         if (table % has_key(field)) then
      |            1
Error: Dummy argument ‘table’ with INTENT(IN) in variable definition context (actual argument to INTENT = OUT/INOUT) at (1)
compilation terminated due to -fmax-errors=1.
<ERROR> Compilation failed for object " src_utils_toml.f90.o "
<ERROR> stopping due to failed compilation
STOP 1
```