### PR TITLE
doc: bump sphinx-book-theme

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 ablog
-sphinx-book-theme~=0.3.3
+sphinx-book-theme~=1.0.0
 sphinx-copybutton
 sphinx-design
 urllib3<2


### PR DESCRIPTION
At the moment readthedocs build fails due to broken dependency.