### PR TITLE
build: add option to turn off test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ project(
 
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
+include(CTest) # option(BUILD_TESTING). ON by default.
 
 # General configuration information
 add_subdirectory("config")
@@ -89,6 +90,8 @@ install(
 )
 
 # add the testsuite
-enable_testing()
-set(fpm-toml "${PROJECT_SOURCE_DIR}/fpm.toml")
-add_subdirectory("test")
+if(BUILD_TESTING)
+  enable_testing()
+  set(fpm-toml "${PROJECT_SOURCE_DIR}/fpm.toml")
+  add_subdirectory("test")
+endif()

--- a/meson.build
+++ b/meson.build
@@ -74,5 +74,7 @@ if install
 endif
 
 # add the testsuite
-fpm_toml = meson.current_source_dir()/'fpm.toml'
-subdir('test')
+if get_option('tests')
+  fpm_toml = meson.current_source_dir()/'fpm.toml'
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,14 @@
+# This file is part of toml-f.
+# SPDX-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of Apache License, Version 2.0 or MIT license
+# at your option; you may not use this file except in compliance with
+# the License.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option('tests', type: 'boolean', value: true, description: 'Enable building and running tests')


### PR DESCRIPTION
- add meson option to disable tests
- use [ctest BUILD_TESTING](https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html) rather than ENABLE_TESTING

---

Add option to disable tests so that there is no need to have `test-drive` dependency.

```
test/unit/meson.build:14:16: ERROR: Dependency 'test-drive' is required but not found.
```