### PR TITLE
Enh : Follow Fortran standards (alloctable variables)

### DIFF
--- a/src/tomlf/diagnostic.f90
+++ b/src/tomlf/diagnostic.f90
@@ -293,6 +293,7 @@ pure function render_text_with_labels(input, label, color, source) result(string
    logical, allocatable :: display(:)
 
    allocate(token(0))  ! avoid compiler warning
+   allocate(character(len=0) :: string) ! Allocate to avoid referencing an unallocated variable
    token = line_tokens(input)
    line(:) = [(count(token%first <= label(it)%first), it = 1, size(label))]
    shift(:) = token(line)%first - 1


### PR DESCRIPTION
Fixes #164 

The fix is needed in [LFortran](https://github.com/lfortran/lfortran) as it blocked our CI.
For now we'll have a workaround in LFortran by using our own fork with the change addressed here, but we'd like to keep our-fork/upstream diff as minimal as possible so it would be great to merge this.