### PR TITLE
Update README to mention support for TOML 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A TOML parser implementation for data serialization and deserialization in Fortran.
 
 * the [TOML standard](https://toml.io)
-* currently supported [TOML v1.0.0 specification](https://toml.io/en/v1.0.0)
+* currently supported [TOML v1.1.0 specification](https://toml.io/en/v1.1.0)
 * [TOML Fortran documentation](https://toml-f.readthedocs.io)
 
 <div align="center">


### PR DESCRIPTION
Release notes for 0.5.0 say it supports TOML 1.1 and it runs against toml-test -toml=1.1, but the README still said 1.0

Signed-off-by: Martin Tournoij \<martin@arp242.net>